### PR TITLE
Update kMandarin_overwrite.txt

### DIFF
--- a/kMandarin_overwrite.txt
+++ b/kMandarin_overwrite.txt
@@ -62,3 +62,37 @@ U+295F5: zhēng  # 𩗵
 U+29B5D: wǒ  # 𩭝
 U+2A048: zhuāng  # 𪁈
 U+2A2A2: shí  # 𪊢
+
+# 日本汉字读音
+U+5302: xiōng,yún # 匂, yún 为日本汉字读音; xiōng 为现代汉语读音;
+U+4E3C: jǐng,dǎn  # 丼, dǎn 为日本汉字读音; jǐng 为现代汉语读音;
+U+8FBB: shí # 辻
+U+8FBC: rù # 込
+U+51E7: jīn # 凧
+U+6763: shān # 杣
+U+67A0: zá # 枠
+U+7551: tián # 畑
+U+6803: lì # 栃
+U+6802: méi # 栂
+U+5CE0: kǎ # 峠
+U+4FE3: yǔ # 俣
+U+7C7E: rèn # 籾
+U+7560: tián # 畠
+U+96EB: xià # 雫
+U+7B39: shì # 笹
+U+5840: píng # 塀
+U+6919: chāng # 椙
+U+7872: yù # 硲
+U+86EF: lǎo # 蛯
+U+55B0: cān # 喰
+U+643E: zhà # 搾
+U+698A: shén # 榊
+U+50CD: dòng # 働
+U+7CC0: huā # 糀
+U+9786: bǐng # 鞆
+U+69C7: zhēn # 槇
+U+6A2B: jīan # 樫
+U+9D2B: tián # 鴫
+U+567A: xīn # 噺
+U+7C17: liáng # 簗
+U+9EBF: mó # 麿


### PR DESCRIPTION
解决问题 #32 : 新增日本汉字读音数据

日本自造汉字和中国传统汉字冲突:

日本汉字读音:
```text
U+5302: yún # 匂
U+4E3C: dǎn # 丼
```

中国传统汉字:
```text
U+5302: xiōng     # 匂, 来源 kMandarin.txt
U+4E3C: jǐng,dǎn  # 丼, 来源 kMandarin.txt 以及 kHanyuPinyin.txt
```

合并处理后为:
```text
U+5302: xiōng,yún # 匂, yún 为日本汉字读音; xiōng 为现代汉语读音;
U+4E3C: jǐng,dǎn  # 丼, dǎn 为日本汉字读音; jǐng 为现代汉语读音; 
```
